### PR TITLE
added boatism speed handling

### DIFF
--- a/src/main/kotlin/cc/tweaked_programs/partnership/main/compat/Compat.kt
+++ b/src/main/kotlin/cc/tweaked_programs/partnership/main/compat/Compat.kt
@@ -5,11 +5,12 @@ import cc.tweaked_programs.partnership.main.compat.boatism.BoatismImpl
 import net.fabricmc.loader.api.FabricLoader
 
 object Compat {
+    const val MOD_ID_BOATISM = "boatism"
 
     var boatism: BoatismCompat = BoatismCompat()
 
     fun check() {
-        if (FabricLoader.getInstance().isModLoaded("boatism"))
+        if (FabricLoader.getInstance().isModLoaded(MOD_ID_BOATISM))
             boatism = BoatismImpl()
     }
 }

--- a/src/main/kotlin/cc/tweaked_programs/partnership/main/compat/boatism/BoatismCompat.kt
+++ b/src/main/kotlin/cc/tweaked_programs/partnership/main/compat/boatism/BoatismCompat.kt
@@ -1,8 +1,10 @@
 package cc.tweaked_programs.partnership.main.compat.boatism
 
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.vehicle.Boat
 
 
 open class BoatismCompat {
     open fun isEngine(entity: Entity): Boolean = false
+    open fun calculateThrust(boat: Boat): Float = 0.0f
 }

--- a/src/main/kotlin/cc/tweaked_programs/partnership/main/compat/boatism/BoatismImpl.kt
+++ b/src/main/kotlin/cc/tweaked_programs/partnership/main/compat/boatism/BoatismImpl.kt
@@ -1,8 +1,27 @@
 package cc.tweaked_programs.partnership.main.compat.boatism
 
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.vehicle.Boat
 import net.shirojr.boatism.entity.custom.BoatEngineEntity
+import net.shirojr.boatism.util.BoatEngineCoupler
+import net.shirojr.boatism.util.EntityHandler
+import java.util.*
+import kotlin.jvm.optionals.getOrNull
 
 class BoatismImpl : BoatismCompat() {
     override fun isEngine(entity: Entity): Boolean = (entity is BoatEngineEntity)
+    override fun calculateThrust(boat: Boat): Float {
+        val coupler = boat as BoatEngineCoupler
+        var speed = 0.0f
+        coupler.`boatism$getBoatEngineEntityUuid`()?.let { uuid: Optional<UUID> ->
+            {
+                EntityHandler.getBoatEngineEntityFromUuid(uuid.getOrNull(), boat.level(), boat.position(), 10)?.also {
+                    val thrust = it.get().engineHandler.calculateThrustModifier(boat)
+                    val powerLevel = it.get().powerLevel * 0.008f
+                    speed = powerLevel * thrust
+                }
+            }
+        }
+        return speed
+    }
 }

--- a/src/main/kotlin/cc/tweaked_programs/partnership/main/entity/GenericBoat.kt
+++ b/src/main/kotlin/cc/tweaked_programs/partnership/main/entity/GenericBoat.kt
@@ -1,5 +1,6 @@
 package cc.tweaked_programs.partnership.main.entity
 
+import cc.tweaked_programs.partnership.main.compat.Compat
 import net.minecraft.util.Mth
 import net.minecraft.world.entity.EntityType
 import net.minecraft.world.entity.vehicle.Boat
@@ -33,6 +34,8 @@ abstract class GenericBoat(type: EntityType<out Boat>, level: Level) : Boat(type
             speed += maxSpeed
         if (inputDown)
             speed -= backwardsSpeed
+
+        speed += Compat.boatism.calculateThrust(this)
 
         deltaMovement = deltaMovement.add(
             (Mth.sin(-yRot * MAGIKK) * speed).toDouble(),


### PR DESCRIPTION
This PR adds speed handling for Partnership boats back.
I usually don't work with Kotlin, so some things might be more clean or work better with a different syntax.

Also, the thrust values have been taken over from the base Boatism code. So a rebalance might be needed to make it be more in line with the performance which is expected from Partnership boats.